### PR TITLE
Multiple attachments can be added

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,21 +33,21 @@
 
         <!-- Attachment Upload -->
         <div class="mb-6 p-4 bg-green-50 rounded-lg">
-            <h3 class="text-lg font-semibold mb-3">Step 2: Upload Common Attachment</h3>
+            <h3 class="text-lg font-semibold mb-3">Step 2: Upload Common Attachment(s)</h3>
             <form id="attachmentForm" class="space-y-3">
-                <input type="file" id="attachment" accept=".pdf,.doc,.docx,.txt,.jpg,.png" required 
+                <input type="file" id="attachment" accept=".pdf,.doc,.docx,.txt,.jpg,.png" required multiple
                        class="block w-full file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-green-100 file:text-green-700 hover:file:bg-green-200">
                 <button type="submit" class="px-6 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition duration-300">
-                    📎 Upload Attachment
+                    📎 Upload Attachment(s)
                 </button>
             </form>
             <div id="attachmentStatus" class="mt-2 text-sm"></div>
             
-            <!-- Current Attachment Info -->
+            <!-- Current Attachments Info -->
             <div id="currentAttachment" class="mt-3 p-3 bg-white rounded border hidden">
                 <div class="text-sm">
-                    <strong>📄 Current Attachment:</strong> 
-                    <span id="currentAttachmentName" class="text-green-600 font-medium"></span>
+                    <strong>📄 Current Attachment(s):</strong> 
+                    <ul id="currentAttachmentList" class="text-green-600 font-medium list-disc list-inside"></ul>
                 </div>
             </div>
         </div>
@@ -96,7 +96,7 @@ Best regards,
         <div id="status" class="mt-6 p-4 bg-green-50 rounded-lg text-green-700 text-sm hidden"></div>
         <div id="error" class="mt-6 p-4 bg-red-50 rounded-lg text-red-700 text-sm hidden"></div>
 
-        </div>
+    </div>
     <script src="/static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Updated index.html
  - Added `multiple` attribute to the attachment input field to allow selecting multiple files.
  - Updated the label to “Upload Common Attachment(s)” to indicate multiple files are supported.
  - Changed the “Current Attachment” display to a list (`<ul id="currentAttachmentList">`) to show multiple filenames.
- Updated script.js
  - Modified the attachment upload handler to send multiple files using the key `'attachments'`.
  - Updated `showCurrentAttachment` to display a list of filenames in the UI.
  - Adjusted the draft creation success message to show multiple attachment names.
- Updated app.py
  - Replaced `ATTACHMENT_PATH` and `ORIGINAL_FILENAME` with lists (`ATTACHMENT_PATHS`, `ORIGINAL_FILENAMES`).
  - Updated `/upload_attachment` route to handle multiple files with the key `'attachments'` and validate file extensions.
  - Modified `create_message_with_attachment` to attach all files to the email.
  - Updated success messages to reflect the number of attachments.
  - Adjusted `/attachment_info` to return lists of filenames and paths.