### PR TITLE
Email Template Preview

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,6 +171,53 @@ def upload_attachment():
 
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 500
+    
+@app.route("/preview_emails", methods=["POST"])
+def preview_emails():
+    """
+    Generate a preview of emails by replacing placeholders in the template.
+
+    Returns:
+        JSON response with a list of previews (email, subject, body) for each recipient.
+    """
+    try:
+        file = request.files["excel_file"]
+        template = request.form["template"]
+
+        if not file:
+            return jsonify({
+                "status": "error",
+                "message": "No Excel file uploaded",
+            }), 400
+
+        # Read Excel file
+        df = pd.read_excel(file, engine="openpyxl")
+        required_columns = ["email", "company_name", "subject"]
+        if not all(col in df.columns for col in required_columns):
+            return jsonify({
+                "status": "error",
+                "message": "Excel file must contain: email, company_name, subject columns",
+            }), 400
+
+        previews = []
+        for index, row in df.iterrows():
+            email = row["email"]
+            company_name = row["company_name"]
+            subject = row["subject"]
+            body = template.format(company_name=company_name)
+            previews.append({
+                "email": email,
+                "subject": subject,
+                "body": body,
+            })
+
+        return jsonify({
+            "status": "success",
+            "previews": previews,
+        })
+
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 500
 
 @app.route('/create_drafts', methods=['POST'])
 def create_drafts():

--- a/index.html
+++ b/index.html
@@ -81,7 +81,14 @@ Best regards,
 [Your Phone Number]
 [Your Email]</textarea>
                 </div>
-                <div class="text-center">
+                <div class="text-center space-x-4">
+                    <button type="button" id="previewButton" class="inline-flex items-center px-8 py-3 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700 transition duration-300">
+                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+                        </svg>
+                        👁️ Preview Emails
+                    </button>
                     <button type="submit" class="inline-flex items-center px-8 py-3 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700 transition duration-300">
                         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
@@ -90,6 +97,21 @@ Best regards,
                     </button>
                 </div>
             </form>
+        </div>
+
+        <!-- Preview Modal -->
+        <div id="previewModal" class="fixed inset-0 bg-gray-600 bg-opacity-50 flex items-center justify-center hidden">
+            <div class="bg-white rounded-lg p-6 w-full max-w-2xl max-h-[80vh] overflow-y-auto">
+                <div class="flex justify-between items-center mb-4">
+                    <h3 class="text-lg font-semibold">Email Preview</h3>
+                    <button id="closePreview" class="text-gray-500 hover:text-gray-700">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                        </svg>
+                    </button>
+                </div>
+                <div id="previewContent" class="space-y-4"></div>
+            </div>
         </div>
 
         <!-- Results Display -->

--- a/script.js
+++ b/script.js
@@ -31,6 +31,76 @@ function showCurrentAttachment(filenames) {
     currentAttachmentDiv.classList.remove('hidden');
 }
 
+// Handle preview emails
+document.getElementById('previewButton').addEventListener('click', async function(event) {
+    event.preventDefault();
+    
+    const excelFile = document.getElementById('excel_file').files[0];
+    const template = document.getElementById('template').value;
+    const previewModal = document.getElementById('previewModal');
+    const previewContent = document.getElementById('previewContent');
+    const errorDiv = document.getElementById('error');
+    
+    // Hide previous messages
+    errorDiv.classList.add('hidden');
+    
+    if (!excelFile) {
+        showMessage(errorDiv, 'Please upload an Excel file first', 'error');
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('excel_file', excelFile);
+    formData.append('template', template);
+
+    try {
+        const response = await fetch('/preview_emails', {
+            method: 'POST',
+            body: formData
+        });
+        const result = await response.json();
+
+        if (result.status === 'error') {
+            showMessage(errorDiv, result.message, 'error');
+            return;
+        }
+
+        // Clear previous preview content
+        previewContent.innerHTML = '';
+
+        // Display each previewed email
+        result.previews.forEach(preview => {
+            const previewDiv = document.createElement('div');
+            previewDiv.className = 'border-b border-gray-200 pb-4';
+            previewDiv.innerHTML = `
+                <div class="mb-2">
+                    <strong>To:</strong> <span class="text-blue-600">${preview.email}</span>
+                </div>
+                <div class="mb-2">
+                    <strong>Subject:</strong> <span class="text-blue-600">${preview.subject}</span>
+                </div>
+                <div class="mb-2">
+                    <strong>Body:</strong>
+                    <div class="mt-1 text-gray-700 whitespace-pre-wrap">${preview.body}</div>
+                </div>
+            `;
+            previewContent.appendChild(previewDiv);
+        });
+
+        // Show the modal
+        previewModal.classList.remove('hidden');
+        
+    } catch (err) {
+        showMessage(errorDiv, `Error: ${err.message}`, 'error');
+    }
+});
+
+// Close preview modal
+document.getElementById('closePreview').addEventListener('click', function() {
+    const previewModal = document.getElementById('previewModal');
+    previewModal.classList.add('hidden');
+});
+
 // Handle attachment upload
 document.getElementById('attachmentForm').addEventListener('submit', async function(event) {
     event.preventDefault();


### PR DESCRIPTION
- Updated index.html 
  - Added a "Preview Emails" button with an eye icon next to the "Create Draft Emails" button in the email creation form.
  - Added a modal (`<div id="previewModal">`) to display the previewed emails, including a close button.
  - Styled the modal using Tailwind CSS for a clean, scrollable overlay with a semi-transparent background.
- Updated script.js
  - Added a click handler for the "Preview Emails" button to send the Excel file and template to the new `/preview_emails` endpoint.
  - Dynamically generates preview content in the modal, displaying the email address, subject, and body for each recipient.
  - Added a handler to close the preview modal when the "X" button is clicked.
  - Preserved existing functionality for attachment upload and draft creation.
- Updated app.py 
  - Added a new `/preview_emails` route (located between `/upload_attachment` and `/create_drafts` routes) to handle POST requests.
  - The route processes the Excel file and template, replaces the `{company_name}` placeholder for each recipient, and returns a JSON response with a list of previews (email, subject, body).
  - Includes validation to ensure the Excel file is uploaded and contains the required columns (`email`, `company_name`, `subject`).
  - Preserved existing routes and functionality (e.g., `/upload_attachment`, `/create_drafts`).